### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
-  - "pip3 install --upgrade pip"
-  - "pip3 install --upgrade wheel setuptools twine"
+  - "python -m pip install --upgrade pip"
+  - "python -m pip install --upgrade wheel setuptools twine"
 
 build: off
 


### PR DESCRIPTION
According to the [pip documentation](https://pip.pypa.io/en/stable/installing/#upgrading-pip), `python -m pip install -U pip` should be used under Windows instead of `pip3 install…`.